### PR TITLE
Cran release fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: shiny.semantic
 Type: Package
-Title: Semantic Ui Support for Shiny
+Title: Semantic UI Support for Shiny
 Version: 0.1.1
 Authors@R: person("Filip", "Stachura", email = "filip@appsilondatascience.com",
   role = c("aut", "cre"))
 Description: Creating great user interface for your Shiny apps
-    can be a hassle, especialy if you want to work purely in R
+    can be a hassle, especially if you want to work purely in R
     and don't want to use, for instance HTML templates. This
     package add support for powerful UI library Semantic UI -
-    http://semantic-ui.com/. You can also find support for
+    <http://semantic-ui.com/>. You can also find support for
     universal UI input binding that works with various DOM elements.
 BugReports: https://github.com/Appsilon/shiny.semantic/issues
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,12 +4,12 @@ Title: Semantic UI Support for Shiny
 Version: 0.1.1
 Authors@R: person("Filip", "Stachura", email = "filip@appsilondatascience.com",
   role = c("aut", "cre"))
-Description: Creating great user interface for your Shiny apps
+Description: Creating a great user interface for your Shiny apps
     can be a hassle, especially if you want to work purely in R
     and don't want to use, for instance HTML templates. This
-    package add support for powerful UI library Semantic UI -
-    <http://semantic-ui.com/>. You can also find support for
-    universal UI input binding that works with various DOM elements.
+    package adds support for a powerful UI library Semantic UI -
+    <http://semantic-ui.com/>. It also supports universal UI input 
+    binding that works with various DOM elements.
 BugReports: https://github.com/Appsilon/shiny.semantic/issues
 Encoding: UTF-8
 LazyData: TRUE

--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,2 @@
-The shiny.semantic package as a whole is distributed under MIT license.
-
-The MIT License (MIT)
-Copyright (c) 2016 Appsilon Sp. z o.o.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+YEAR: 2016
+COPYRIGHT HOLDER: Appsilon Sp. z o.o.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+=====================
+
+Copyright © 2016 Appsilon Sp. z o.o.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/inst/prepare_package_cran.sh
+++ b/inst/prepare_package_cran.sh
@@ -5,7 +5,7 @@ cd $BASENAME/..
 git checkout -B temp_cran_release
 
 echo "==> Preparing package for CRAN release."
-rm -r build/ docs/ examples/ CHANGELOG.md README.Rmd README_files build_readme.R examples/ readme_assets/ readme_rmd_template/ inst/semantic/.versions
+rm -r build/ docs/ examples/ LICENSE.md CHANGELOG.md README.Rmd README_files build_readme.R examples/ readme_assets/ readme_rmd_template/ inst/semantic/.versions
 
 mkdir build
 


### PR DESCRIPTION
Created new LICENSE.md file with full MIT license text. LICENSE file shortened as MIT template requires.
Fixed other simple notes such as mis-spelled words and form of urls in Description section.