### PR TITLE
Update modal documentation

### DIFF
--- a/R/modal.R
+++ b/R/modal.R
@@ -84,6 +84,30 @@
 #'   })
 #' })
 #'
+#' ## Changing attributes of header and content.
+#' library(shiny)
+#' library(shiny.semantic)
+#'
+#' ui <- function() {
+#'   shinyUI(
+#'     semanticPage(
+#'       actionButton("show", "Show modal dialog")
+#'     )
+#'   )
+#' }
+#'
+#' server = function(input, output) {
+#'   observeEvent(input$show, {
+#'     create_modal(modal(
+#'       id = "simple-modal",
+#'       title = "Important message",
+#'       header = list(style = "background: lightcoral"),
+#'       content = list(style = "background: lightblue", `data-custom` = "value", "This is an important message!"),
+#'       p("This is also part of the content!")
+#'     ))
+#'   })
+#' }
+#'
 #' @import shiny
 #' @export
 modal <- function(...,

--- a/R/modal.R
+++ b/R/modal.R
@@ -2,12 +2,12 @@
 #'
 #' This creates a modal using Semantic UI styles.
 #'
-#' @param ... Content to be displayed in the modal body.
+#' @param ... Content elements to be added to the modal body. To change attributes of the container please check the `content` argument.
 #' @param id ID to be added to the modal div. Default "".
 #' @param class Classes except "ui modal" to be added to the modal. Semantic UI classes can be used. Default "".
-#' @param header Content to be displayed in the modal header. Default "".
-#' @param content Content to be displayed in the modal body.
-#' @param footer Content to be displayed in the modal footer. Usually for buttons. Default NULL.
+#' @param header Content to be displayed in the modal header. If given in form of a list, HTML attributes for the container can also be changed. Default "".
+#' @param content Content to be displayed in the modal body. If given in form of a list, HTML attributes for the container can also be changed. Default NULL.
+#' @param footer Content to be displayed in the modal footer. Usually for buttons. If given in form of a list, HTML attributes for the container can also be changed. Default NULL.
 #' @param target Javascript selector for the element that will open the modal. Default NULL.
 #' @param settings List of vectors of Semantic UI settings to be added to the modal. Default NULL.
 #' @param modal_tags Other modal elements. Default NULL.

--- a/examples/modal/app_5.R
+++ b/examples/modal/app_5.R
@@ -1,0 +1,24 @@
+library(shiny)
+library(shiny.semantic)
+
+ui <- function() {
+  shinyUI(
+    semanticPage(
+      actionButton("show", "Show modal dialog")
+    )
+  )
+}
+
+server = function(input, output) {
+  observeEvent(input$show, {
+    create_modal(modal(
+      id = "simple-modal",
+      title = "Important message",
+      header = list(style = "background: lightcoral"),
+      content = list(style = "background: lightblue", `data-custom` = "value", "This is an important message!"),
+      p("This is also part of the content!")
+    ))
+  })
+}
+
+shinyApp(ui = ui(), server = server)

--- a/man/modal.Rd
+++ b/man/modal.Rd
@@ -8,17 +8,17 @@ modal(..., id = "", class = "", header = "", content = NULL,
   footer = NULL, target = NULL, settings = NULL, modal_tags = NULL)
 }
 \arguments{
-\item{...}{Content to be displayed in the modal body.}
+\item{...}{Content elements to be added to the modal body. To change attributes of the container please check the `content` argument.}
 
 \item{id}{ID to be added to the modal div. Default "".}
 
 \item{class}{Classes except "ui modal" to be added to the modal. Semantic UI classes can be used. Default "".}
 
-\item{header}{Content to be displayed in the modal header. Default "".}
+\item{header}{Content to be displayed in the modal header. If given in form of a list, HTML attributes for the container can also be changed. Default "".}
 
-\item{content}{Content to be displayed in the modal body.}
+\item{content}{Content to be displayed in the modal body. If given in form of a list, HTML attributes for the container can also be changed. Default NULL.}
 
-\item{footer}{Content to be displayed in the modal footer. Usually for buttons. Default NULL.}
+\item{footer}{Content to be displayed in the modal footer. Usually for buttons. If given in form of a list, HTML attributes for the container can also be changed. Default NULL.}
 
 \item{target}{Javascript selector for the element that will open the modal. Default NULL.}
 


### PR DESCRIPTION
# Updated modal content documentation.

Closes #125

Updated documentation to better explain the difference between using `...` and content. In general:

- `...` can be used as a quick way to add elements to the modal content. This is the most common use.

- `content` allows developers to fully customize the attributes of the content container. This includes HTML attributes such as data or classes for example. This rule is also true for the `header` and `footer` arguments.
