### PR TITLE
added margin to semanticpage

### DIFF
--- a/R/semanticPage.R
+++ b/R/semanticPage.R
@@ -126,9 +126,12 @@ check_semantic_theme <- function(theme_css, full_url = TRUE) {
 #' @param title A title to display in the browser's title bar.
 #' @param theme Theme name or path. Full list of supported themes you will find in
 #' \code{SUPPORTED_THEMES} or at http://semantic-ui-forest.com/themes.
+#' @param supress_bootstrap boolean flag that supresses bootstrap when turned on
+#' @param margin character with body margin size
 #'
 #' @export
-semanticPage <- function(..., title = "", theme = NULL, supress_bootstrap = TRUE) {
+semanticPage <- function(..., title = "", theme = NULL, supress_bootstrap = TRUE,
+                         margin = "10px") {
   content <- shiny::tags$div(class = "wrapper", ...)
   if (supress_bootstrap) {
     supress_bootstrap <- suppressDependencies("bootstrap")
@@ -151,7 +154,7 @@ semanticPage <- function(..., title = "", theme = NULL, supress_bootstrap = TRUE
       shiny::tags$script(src = "shiny.semantic/shiny-semantic-numericinput.js"),
       shiny::tags$script(src = "shiny.semantic/shiny-semantic-rating.js")
     ),
-    shiny::tags$body(style = "margin:10px; min-height: 611px;",
+    shiny::tags$body(style = glue::glue("margin:{margin}; min-height: 611px;"),
                      supress_bootstrap,
                      content)
   )

--- a/R/semanticPage.R
+++ b/R/semanticPage.R
@@ -151,7 +151,7 @@ semanticPage <- function(..., title = "", theme = NULL, supress_bootstrap = TRUE
       shiny::tags$script(src = "shiny.semantic/shiny-semantic-numericinput.js"),
       shiny::tags$script(src = "shiny.semantic/shiny-semantic-rating.js")
     ),
-    shiny::tags$body(style = "min-height: 611px;",
+    shiny::tags$body(style = "margin:10px; min-height: 611px;",
                      supress_bootstrap,
                      content)
   )

--- a/man/semanticPage.Rd
+++ b/man/semanticPage.Rd
@@ -4,7 +4,13 @@
 \alias{semanticPage}
 \title{Semantic UI page}
 \usage{
-semanticPage(..., title = "", theme = NULL, supress_bootstrap = TRUE)
+semanticPage(
+  ...,
+  title = "",
+  theme = NULL,
+  supress_bootstrap = TRUE,
+  margin = "10px"
+)
 }
 \arguments{
 \item{...}{Other arguments to be added as attributes of the main div tag
@@ -14,6 +20,10 @@ wrapper (e.g. style, class etc.)}
 
 \item{theme}{Theme name or path. Full list of supported themes you will find in
 \code{SUPPORTED_THEMES} or at http://semantic-ui-forest.com/themes.}
+
+\item{supress_bootstrap}{boolean flag that supresses bootstrap when turned on}
+
+\item{margin}{character with body margin size}
 }
 \description{
 This creates a Semantic page for use in a Shiny app.


### PR DESCRIPTION
# Default margin in semantic Page

Without margin all our examples look like this:
<img width="1128" alt="Screenshot 2020-06-20 at 11 03 12" src="https://user-images.githubusercontent.com/4547289/85268241-2a760000-b46e-11ea-8634-b72024e7bc82.png">

margin highlights the shading and other elements.
