### PR TITLE
Fix passing `value` as `label` in `textInput`

### DIFF
--- a/R/input.R
+++ b/R/input.R
@@ -141,7 +141,7 @@ textInput <- function(inputId, label, value = "", width = NULL,
     style = if (!is.null(width)) glue::glue("width: {shiny::validateCssUnit(width)};"),
     shiny::div(class = "field",
                if (!is.null(label)) tags$label(label, `for` = inputId),
-               text_input(inputId, value, placeholder = placeholder, type = type)
+               text_input(inputId, value = value, placeholder = placeholder, type = type)
     )
   )
 }


### PR DESCRIPTION
The second argument of `shiny::testInput` is `label`. This caused that `value` was passed as `label`.