### PR TITLE
Remove inline-styled min-height from <body>

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shiny.semantic
 Type: Package
 Title: Semantic UI Support for Shiny
-Version: 0.4.2
+Version: 0.4.3
 Authors@R: c(person("Filip", "Stachura", email = "filip@appsilon.com", role = "aut"),
   person("Dominik", "Krzeminski", email = "dominik@appsilon.com", role = "cre"),
   person("Krystian", "Igras", email = "krystian@appsilon.com", role = "aut"),

--- a/R/semanticPage.R
+++ b/R/semanticPage.R
@@ -173,7 +173,7 @@ semanticPage <- function(..., title = "", theme = NULL, suppress_bootstrap = TRU
       shiny::tags$script(src = "shiny.semantic/shiny-semantic-progress.js"),
       shiny::tags$script(src = "shiny.semantic/shiny-semantic-toast.js")
     ),
-    shiny::tags$body(style = glue::glue("margin:{margin}; min-height: 611px;"),
+    shiny::tags$body(style = glue::glue("margin:{margin};"),
                      suppress_bootstrap,
                      ...)
   )


### PR DESCRIPTION
Inline styles are bad. Setting min-height of `<body>` to a magic number is bad.
This small PR removes two bad things contained in just a few characters.

This `min-height` was causing real responsiveness problems in `semantic.dashboard` that had to be overwritten using `!important` which is bad but is (soon hopefully _was_ necessary).

**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [x] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
