### PR TITLE
Fixing - Tabset won't work after changing its class trough the menu_class arg

### DIFF
--- a/inst/www/shiny-semantic-tabset.js
+++ b/inst/www/shiny-semantic-tabset.js
@@ -2,7 +2,7 @@ var semanticTabset = new Shiny.InputBinding();
 
 $.extend(semanticTabset, {
   find: function(scope) {
-    return $(scope).find('.tabular.menu');
+    return $(scope).find('.ui.menu.sem');
   },
   initialize: function(el){
     $(el).find('.item').tab();


### PR DESCRIPTION
Related to this [issue](https://github.com/Appsilon/shiny.semantic/issues/347)

When using a `tabset` and setting a class different of `.tabular.menu` as @ashbaldry suggested, the `find` method was unable to find the newly set class and hence unable to run the others method as expected. 
Setting the scope of the find function as `ui.menu.sem` once again as @ashbaldry suggested, fix the issue. 

**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
