### PR TITLE
inline works for checkbox and radio

### DIFF
--- a/R/checkbox.R
+++ b/R/checkbox.R
@@ -140,11 +140,13 @@ multiple_checkbox <- function(input_id, label, choices, choices_value = choices,
     )
   }))
 
-  shiny::div(
-    id = input_id, class = paste(position, "fields shiny-input-checkboxgroup"),
-    tags$label(`for` = input_id, label),
-    choices_html,
-    ...
+  shiny::div(class="ui form",
+    shiny::div(
+      id = input_id, class = paste(position, "fields shiny-input-checkboxgroup"),
+      tags$label(`for` = input_id, label),
+      choices_html,
+      ...
+    )
   )
 }
 
@@ -168,10 +170,12 @@ multiple_radio <- function(input_id, label, choices, choices_value = choices,
     )
   }))
 
-  shiny::div(
-    id = input_id, class = paste(position, "fields shiny-input-radiogroup"),
-    tags$label(`for` = input_id, label),
-    choices_html,
-    ...
+  shiny::div(class="ui form",
+    shiny::div(
+      id = input_id, class = paste(position, "fields shiny-input-radiogroup"),
+      tags$label(`for` = input_id, label),
+      choices_html,
+      ...
+    )
   )
 }


### PR DESCRIPTION
To get position="inline" to work for multiple_radio() and multiple_checkbox(), i had to wrap it in div(class="ui form", ...). Not sure how this will affect things downstream. Let me know what you think and I can add tests.

Reprex:

```R
library(shiny)
library(shiny.semantic)

ui <- semanticPage(
  multiple_radio("radioboxes1", "Select Letter", LETTERS[1:6], value = "A"),
  multiple_radio("radioboxes2", "Select Letter", LETTERS[1:10], value = "A", position='inline'),
  multiple_checkbox("checkboxes1", "Select Letter", LETTERS[1:6], value = "A"),
  multiple_checkbox("checboxes2", "Select Letter", LETTERS[1:10], value = "A", position='inline')
)
server <- function(input, output, session) {}
shinyApp(ui, server)
```

**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
