### PR TITLE
Enabling Progress Bar to Update in Loops. Fixes #359

### DIFF
--- a/R/progress.R
+++ b/R/progress.R
@@ -73,9 +73,9 @@ progress <- function(input_id, value = NULL, total = NULL, percent = NULL, progr
 #' @export
 update_progress <- function(session, input_id, type = c("increment", "decrement", "label", "value"), value = 1) {
   type <- match.arg(type)
-  message <- structure(list(value), names = type)
+  message <- list(id = input_id, type = type, value = value)
 
-  session$sendInputMessage(input_id, message)
+  session$sendCustomMessage("ssprogress", list(type = "change", message = message))
 }
 
 #' Reporting progress (object-oriented API)

--- a/examples/progress/app.R
+++ b/examples/progress/app.R
@@ -15,7 +15,7 @@ ui <- semanticPage(
       "percent_ex", percent = 35, progress_lab = TRUE, label = "{percent}% complete", label_complete = "All done!"
     ),
     tags$br(),
-    button("button2", "Increase b 5%"),
+    button("button2", "Increase by 5%"),
     button("button3", "Decrease by 5%"),
     textOutput("percent_ex")
   )

--- a/inst/www/shiny-semantic-progress.js
+++ b/inst/www/shiny-semantic-progress.js
@@ -1,97 +1,20 @@
 // Shiny input for progress bars
-var semanticProgressBinding = new Shiny.InputBinding();
-
-$.extend(semanticProgressBinding, {
-
-  // This initialize input element. It extracts data-value attribute and use that as value.
-  initialize: function(el) {
-    $(el).progress({
-      text: {
-        active: $(el).data('label'),
-        success: $(el).data('label-complete')
-      }
-    });
-  },
-
-  // This returns a jQuery object with the DOM element.
-  find: function(scope) {
-    return $(scope).find('.ss-progress');
-  },
-
-  // Returns the ID of the DOM element.
-  getId: function(el) {
-    return el.id;
-  },
-
-  // Given the DOM element for the input, return the value as JSON.
-  getValue: function(el) {
-    if ($(el).data('value')) {
-      return $(el).progress('get value');
-    } else {
-      return $(el).progress('get percent');
+renderProgressBars = function() {
+  $('.progress').progress({
+    text: {
+      active: $(this).data('label'),
+      success: $(this).data('label-complete')
+    },
+    onActive: function() {
+      Shiny.setInputValue(this.id, $(this).progress('get value'));
+    },
+    onChange: function() {
+      Shiny.setInputValue(this.id, $(this).progress('get value'));
     }
-  },
+  });
+};
 
-  // Given the DOM element for the input, set the value.
-  setValue: function(el, value) {
-    if ($(el).data('value')) {
-      return $(el).progress('set progress', value);
-    } else {
-      return $(el).progress('set percent', value);
-    }
-  },
-
-  // Set up the event listeners so that interactions with the
-  // input will result in data being sent to server.
-  // callback is a function that queues data to be sent to
-  // the server.
-  subscribe: function(el, callback) {
-    $(el).on('keyup change', function () { callback(true); });
-  },
-
-  // TODO: Remove the event listeners.
-  unsubscribe: function(el) {
-    $(el).off('.semanticProgressBinding');
-  },
-
-  // This returns a full description of the input's state.
-  getState: function(el) {
-    return {
-      value: this.getValue(el)
-    };
-  },
-
-  // The input rate limiting policy.
-  getRatePolicy: function() {
-    return {
-      // Can be 'debounce' or 'throttle':
-      policy: 'debounce',
-      delay: 50
-    };
-  },
-
-  receiveMessage: function(el, data) {
-    if (data.hasOwnProperty('value')) {
-      this.setValue(el, data.value);
-    }
-
-    if (data.hasOwnProperty('label')) {
-      $(el).progress('set label', data.label);
-    }
-
-    if (data.hasOwnProperty('increment')) {
-      $(el).progress('increment', Number(data.increment));
-    }
-
-    if (data.hasOwnProperty('decrement')) {
-      $(el).progress('decrement', Number(data.decrement));
-    }
-
-    $(el).trigger('change');
-  }
-});
-
-Shiny.inputBindings.register(semanticProgressBinding, 'shiny.semanticProgress');
+$(window).on('load', renderProgressBars);
 
 // JS to handle the Progress object similar to shiny
 Shiny.addCustomMessageHandler('ssprogress', function(message) {
@@ -125,6 +48,18 @@ var ssProgressHandlers = {
     $(`#ss-progress-${message.id}`).progress();
   },
 
+  change: function(message) {
+    var progress = $('#' + message.id);
+
+    if (message.type === 'label') {
+      progress.progress('set label', message.value);
+    } else if (message.type === 'value') {
+      progress.progress('set progress', message.value);
+    } else {
+      progress.progress(message.type, message.value);
+    }
+  },
+
   // Update page-level progress bar
   update: function(message) {
     // For new-style (starting in Shiny 0.14) progress indicators that use
@@ -139,7 +74,7 @@ var ssProgressHandlers = {
     }
     if (typeof(message.value) !== 'undefined' && message.value !== null) {
       progress.progress('set progress', message.value);
-      }
+    }
 
   },
 


### PR DESCRIPTION
Unbinding the progress bar as an input, but still accessible through `input$id`. Updates like the `Progress` toast and can be updated server side as before.
Tested against #359 and the 4 updates in the examples and all seem to work okay.

**DoD**

- [x] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [x] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [x] No new error or warning messages are introduced.

- [x] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [x] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [x] All code has been peer-reviewed before merging into any main branch.

- [x] All changes have been merged into the main branch we use for development (develop).

- [x] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [x] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [x] Any added or touched code follows our style-guide.
