### PR TITLE
Fix the build for latest knitr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,5 +49,6 @@ Suggests:
     DT,
     covr,
     leaflet,
-    plotly
+    plotly,
+    rmarkdown
 RoxygenNote: 7.1.1


### PR DESCRIPTION
Fixes the build to work with the latest version of knitr:

```
── R CMD build ─────────────────────────────────────────────────────────────────
* checking for file ‘.../DESCRIPTION’ ... OK
* preparing ‘shiny.semantic’:
* checking DESCRIPTION meta-information ... OK
* installing the package to build vignettes
* creating vignettes ... ERROR
Error: --- re-building ‘fomantic_js.Rmd’ using rmarkdown
Error: Error: processing vignette 'fomantic_js.Rmd' failed with diagnostics:
The 'rmarkdown' package should be installed and declared as a dependency of the 'shiny.semantic' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'rmarkdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building ‘fomantic_js.Rmd’

--- re-building ‘basics.Rmd’ using knitr
Error: Error: processing vignette 'basics.Rmd' failed with diagnostics:
The 'markdown' package should be installed and declared as a dependency of the 'shiny.semantic' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building ‘basics.Rmd’

--- re-building ‘intro.Rmd’ using knitr
Error: Error: processing vignette 'intro.Rmd' failed with diagnostics:
The 'markdown' package should be installed and declared as a dependency of the 'shiny.semantic' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building ‘intro.Rmd’

--- re-building ‘semantic_integration.Rmd’ using knitr
Error: Error: processing vignette 'semantic_integration.Rmd' failed with diagnostics:
The 'markdown' package should be installed and declared as a dependency of the 'shiny.semantic' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building ‘semantic_integration.Rmd’

SUMMARY: processing the following files failed:
  ‘fomantic_js.Rmd’ ‘basics.Rmd’ ‘intro.Rmd’ ‘semantic_integration.Rmd’
```
