### PR TITLE
show warning if default shiny page fct is used

### DIFF
--- a/R/display_warning.R
+++ b/R/display_warning.R
@@ -1,0 +1,43 @@
+#' Generates warning message.
+#'
+#' @param fct Name of the shiny function used.
+page_display_warning <- function(fct) {
+  glue::glue("shiny.semantic is loaded but {fct} is used. This will cause display issues.
+             Please unload shiny.semantic or use semanticPage() instead.")
+}
+
+#' Generates warning message if basicPage is used.
+basicPage <- function(...) {
+  warning(page_display_warning("basicPage"))
+  shiny::basicPage(...)
+}
+
+#' Generates warning message if basicPage is used.
+bootstrapPage <- function(...) {
+  warning(page_display_warning("bootstrapPage"))
+  shiny::bootstrapPage(...)
+}
+
+#' Generates warning message if basicPage is used.
+fillPage <- function(...) {
+  warning(page_display_warning("fillPage"))
+  shiny::fillPage(...)
+}
+
+#' Generates warning message if basicPage is used.
+fixedPage <- function(...) {
+  warning(page_display_warning("fixedPage"))
+  shiny::fixedPage(...)
+}
+
+#' Generates warning message if basicPage is used.
+navbarPage <- function(...) {
+  warning(page_display_warning("navbarPage"))
+  shiny::navbarPage(...)
+}
+
+#' Generates warning message if basicPage is used.
+fluidPage <- function(...) {
+  warning(page_display_warning("fluidPage"))
+  shiny::fluidPage(...)
+}

--- a/R/display_warning.R
+++ b/R/display_warning.R
@@ -12,31 +12,31 @@ basicPage <- function(...) {
   shiny::basicPage(...)
 }
 
-#' Generates warning message if basicPage is used.
+#' Generates warning message if bootstrapPage is used.
 bootstrapPage <- function(...) {
   warning(page_display_warning("bootstrapPage"))
   shiny::bootstrapPage(...)
 }
 
-#' Generates warning message if basicPage is used.
+#' Generates warning message if fillPage is used.
 fillPage <- function(...) {
   warning(page_display_warning("fillPage"))
   shiny::fillPage(...)
 }
 
-#' Generates warning message if basicPage is used.
+#' Generates warning message if fixedPage is used.
 fixedPage <- function(...) {
   warning(page_display_warning("fixedPage"))
   shiny::fixedPage(...)
 }
 
-#' Generates warning message if basicPage is used.
+#' Generates warning message if navbarPage is used.
 navbarPage <- function(...) {
   warning(page_display_warning("navbarPage"))
   shiny::navbarPage(...)
 }
 
-#' Generates warning message if basicPage is used.
+#' Generates warning message if fluidPage is used.
 fluidPage <- function(...) {
   warning(page_display_warning("fluidPage"))
   shiny::fluidPage(...)


### PR DESCRIPTION
Short description (with a reference to an issue).

closes #328 

When using a default shiny page fct (fluidPage,..), a warning message now informs the user that there will be display issues.

**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
