### PR TITLE
Fixed `textAreaInput` value parameter

### DIFF
--- a/R/input.R
+++ b/R/input.R
@@ -125,7 +125,7 @@ textAreaInput <- function(inputId, label, value = "", width = NULL, placeholder 
     style = if (!is.null(width)) glue::glue("width: {shiny::validateCssUnit(width)};"),
     shiny::div(class = "field",
                if (!is.null(label)) tags$label(label, `for` = inputId),
-               text_input(inputId, value,
+               text_input(inputId, value = value,
                           placeholder = placeholder, type = "textarea")
     )
   )

--- a/R/input.R
+++ b/R/input.R
@@ -110,7 +110,7 @@ text_input <- function(input_id, label = NULL, value = "", type = "text",
 #' ## Only run examples in interactive R sessions
 #' if (interactive()) {
 #' ui <- semanticPage(
-#'   textAreaInput("a", "Area:", width = "200px"),
+#'   textAreaInput("a", "Area:", value = "200", width = "200px"),
 #'   verbatimTextOutput("value")
 #' )
 #' server <- function(input, output, session) {

--- a/R/input.R
+++ b/R/input.R
@@ -80,7 +80,7 @@ text_input <- function(input_id, label = NULL, value = "", type = "text",
   }
 
   if (type == "textarea") {
-    input <- tags$textarea(id = input_id, value = value, placeholder = placeholder)
+    input <- tags$textarea(id = input_id, value, placeholder = placeholder)
   } else {
     input <- tags$input(id = input_id, value = value, type = type, placeholder = placeholder)
   }


### PR DESCRIPTION
Closes #370 
The `value` parameter for `textAreaInput()` is currently passed to `text_input()` as the label (#370). This PR fixes that issue.

**DoD**

- [x] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [x] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [x] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [x] If the change affects code or repo structure, README, documentation and code comments should be updated. 

- [x] All code has been peer-reviewed before merging into any main branch.

- [x] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [x] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [x] Any added or touched code follows our style-guide.
