### PR TITLE
Add labels option to calendar range

### DIFF
--- a/R/calendar_range.R
+++ b/R/calendar_range.R
@@ -16,12 +16,15 @@
 #' @param end_placeholder Text visible in the end calendar input when nothing is inputted.
 #' @param min Minimum allowed value in both calendars.
 #' @param max Maximum allowed value in both calendars.
+#' @param start_label Label text in the start calendar.
+#' @param end_label Label text in the end calendar.
 #'
 #' @rdname calendar_range
 #' @export
 #'
 calendar_range <- function(input_id, type = "date", start_value = NULL, end_value = NULL,
-                           start_placeholder = NULL, end_placeholder = NULL, min = NA, max = NA) {
+                           start_placeholder = NULL, end_placeholder = NULL, min = NA, max = NA,
+                           start_label = NULL, end_label = NULL) {
   if (!is.null(start_value)) start_value <- format(as.Date(start_value), "%Y/%m/%d")
   if (!is.null(end_value)) end_value <- format(as.Date(end_value), "%Y/%m/%d")
   if (!is.na(min)) min <- format(as.Date(min), "%Y/%m/%d")
@@ -73,10 +76,12 @@ calendar_range <- function(input_id, type = "date", start_value = NULL, end_valu
       class = "two fields",
       div(
         class = "field",
+        tags$label(start_label),
         start_cal_widget
       ),
       div(
         class = "field",
+        tags$label(end_label),
         end_cal_widget
       )
     )

--- a/examples/calendar_range/app.R
+++ b/examples/calendar_range/app.R
@@ -10,7 +10,9 @@ ui <- semanticPage(
           min = "2020-01-01",
           max = "2020-12-01",
           start_placeholder = "Select range start",
-          end_placeholder = "Select range end"
+          end_placeholder = "Select range end",
+          start_label = "Start Date",
+          end_label = "End Date"
         ),
         div(
           class = "two fields",

--- a/man/calendar_range.Rd
+++ b/man/calendar_range.Rd
@@ -13,7 +13,9 @@ calendar_range(
   start_placeholder = NULL,
   end_placeholder = NULL,
   min = NA,
-  max = NA
+  max = NA,
+  start_label = NULL,
+  end_label = NULL
 )
 
 update_calendar_range(
@@ -41,6 +43,10 @@ update_calendar_range(
 \item{min}{Minimum allowed value in both calendars.}
 
 \item{max}{Maximum allowed value in both calendars.}
+
+\item{start_label}{Label text in the start calendar.}
+
+\item{end_label}{Label text in the end calendar.}
 
 \item{session}{The \code{session} object passed to function given to
 \code{shinyServer}.}


### PR DESCRIPTION
Short description (with a reference to an issue).
This PR adds users an opportunity to add label(s) about the calendar_range input fields, as for now it is quite complicated to add labels above start and end calendars fields precisely.

`        
calendar_range(
          input_id = "calendar_range",
          start_value = "2020-02-20",
          end_value = "2020-03-20",
          min = "2020-01-01",
          max = "2020-12-01",
          start_placeholder = "Select range start",
          end_placeholder = "Select range end",
          start_label = "Start Date",
          end_label = "End Date"
        )
`

In general, to existing `calendar_range` function added two arguments `start_label` and `end_label`
The example app showcasing has been also completed.  `examples/calendar_range`



**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
