### PR TITLE
fix: remove unnecessary warning

### DIFF
--- a/R/checkbox.R
+++ b/R/checkbox.R
@@ -55,7 +55,8 @@ checkbox_input <- function(input_id, label = "", type = NULL, is_marked = TRUE,
 #' @rdname checkbox
 #' @export
 checkboxInput <- function(inputId, label = "", value = FALSE, width = NULL){
-  warn_unsupported_args(c("width"))
+  if (!is.null(width))
+    warn_unsupported_args(c("width"))
   checkbox_input(inputId, label, is_marked = value)
 }
 

--- a/tests/testthat/test_checkbox.R
+++ b/tests/testthat/test_checkbox.R
@@ -24,3 +24,13 @@ test_that("test toggle alias for checkbox_input", {
   expect_true(any(grepl("toggle",
                         si_str2, fixed = TRUE)))
 })
+
+test_that("checkboxInput warns on unsupported arguments", {
+  expect_silent(checkboxInput("check"))
+  expect_silent(checkboxInput("check", NULL))
+  expect_silent(checkboxInput("check", "My Label"))
+  expect_silent(checkboxInput("check", "My Label", TRUE))
+  expect_silent(checkboxInput("check", "My Label", FALSE))
+  expect_silent(checkboxInput("check", width = NULL))
+  expect_warning(checkboxInput("check", width = "10%"))
+})


### PR DESCRIPTION
Prior to this change `checkboxInput()` would throw an error with a default width value. This change makes the warning go off only if width argument is not `NULL`.

Fixes #404 

**DoD**

- [x] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.
- [x] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.
- [x] No new error or warning messages are introduced.
- [x] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.
- [x] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 
- [x] All code has been peer-reviewed before merging into any main branch.
- [ ] All changes have been merged into the main branch we use for development (develop).
- [x] Continuous integration checks (linter, unit tests) are configured and passed.
- [x] Unit tests added for all new or changed logic.
- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.
- [x] Any added or touched code follows our style-guide.
