### PR TITLE
Fixing Duplicated Date Input Icon

### DIFF
--- a/R/date_input.R
+++ b/R/date_input.R
@@ -6,7 +6,6 @@
 #' @param min Minimum date that can be selected.
 #' @param max Maximum date that can be selected.
 #' @param style Css style for widget.
-#' @param icon_name Icon that should be displayed on widget.
 #'
 #' @examples
 #' if (interactive()) {
@@ -44,42 +43,29 @@
 #'
 #' @export
 #' @rdname date_input
-date_input <- function(input_id, label = NULL, value = NULL, min = NULL, max = NULL,
-                       style = NULL, icon_name = "calendar") {
-  class <- paste(input_id, "ui input")
-  if (!is.null(icon))
-    class <- paste(class, "icon")
+date_input <- function(input_id, label = NULL, value = NULL, min = NULL, max = NULL, style = NULL) {
+  if (is.null(min)) min <- NA
+  if (is.null(max)) max <- NA
 
-  shiny::tagList(
-    shiny::div(class = class,
-               style = style,
-               label,
-               shiny.semantic::shiny_text_input(
-                 input_id,
-                 shiny::tags$input(type = "date", name = input_id, min = min, max = max),
-                 value = value),
-               icon(icon_name))
+    shiny::div(
+      class = paste(input_id, "ui input"),
+      style = style,
+      tags$label(label),
+      calendar(input_id, value, min = min, max = max)
     )
 }
 
 #' @param inputId Input id.
-#' @param label Label to be displayed with date input.
-#' @param value Default date chosen for input.
-#' @param min Minimum date that can be selected.
-#' @param max Maximum date that can be selected.
-#' @param icon Icon that should be displayed on widget.
 #' @param width character width of the object
 #' @param ... other arguments
 #'
 #' @rdname date_input
 #' @export
-dateInput <- function(inputId, label = NULL, icon = NULL, value = NULL,
-                      min = NULL, max = NULL, width = NULL, ...) {
+dateInput <- function(inputId, label = NULL, value = NULL, min = NULL, max = NULL, width = NULL, ...) {
   # TODO match arguments with shiny::dateInput
   args_list <- list(...)
   args_list$input_id <- inputId
   args_list$label <- label
-  args_list$icon_name <- icon
   args_list$value <- value
   args_list$min <- min
   args_list$max <- max

--- a/man/date_input.Rd
+++ b/man/date_input.Rd
@@ -11,14 +11,12 @@ date_input(
   value = NULL,
   min = NULL,
   max = NULL,
-  style = NULL,
-  icon_name = "calendar"
+  style = NULL
 )
 
 dateInput(
   inputId,
   label = NULL,
-  icon = NULL,
   value = NULL,
   min = NULL,
   max = NULL,
@@ -39,11 +37,7 @@ dateInput(
 
 \item{style}{Css style for widget.}
 
-\item{icon_name}{Icon that should be displayed on widget.}
-
 \item{inputId}{Input id.}
-
-\item{icon}{Icon that should be displayed on widget.}
 
 \item{width}{character width of the object}
 

--- a/tests/testthat/test_date_input.R
+++ b/tests/testthat/test_date_input.R
@@ -10,12 +10,12 @@ test_that("test dateInput missing input", {
 
 test_that("test date_input output type", {
   expect_is(date_input("date_from", value = Sys.Date()),
-            "shiny.tag.list")
+            "shiny.tag")
 })
 
 test_that("test dateInput output type", {
   expect_is(date_input("date_from", value = Sys.Date()),
-            "shiny.tag.list")
+            "shiny.tag")
 })
 
 test_that("test date_input equals dateInput", {
@@ -29,7 +29,7 @@ test_that("test date_input basic input", {
   si_str <- as.character(
     date_input("date_from", value = Sys.Date())
   )
-  expect_true(any(grepl(paste0("data-value=\"", as.character(Sys.Date()), "\""),
+  expect_true(any(grepl(paste0("data-date=\"", gsub("-", "/", as.character(Sys.Date())), "\""),
                         si_str, fixed = TRUE)))
   # here we chaeck if style param is passed correctly
   si_str <- as.character(


### PR DESCRIPTION
Changed date input to use Fomantic UI calendar rather than basic HTML calendar to prevent duplicate icons - the default calendar icon for `<input type="date">` is visible by default

Resolves #406

**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
