### PR TITLE
Esra labeled inputs ability to set label position

### DIFF
--- a/R/input.R
+++ b/R/input.R
@@ -134,15 +134,41 @@ textAreaInput <- function(inputId, label, value = "", width = NULL, placeholder 
 #' @param inputId Input name. The same as \code{input_id}.
 #' @rdname text_input
 #' @export
-textInput <- function(inputId, label, value = "", width = NULL,
-                      placeholder = NULL, type = "text") {
+textInput <- function(inputId, label, value = "", width = NULL, placeholder = NULL,
+                      type = "text", class = "field", label_class = "ui label") {
   shiny::div(
     class = "ui form",
-    style = if (!is.null(width)) glue::glue("width: {shiny::validateCssUnit(width)};"),
-    shiny::div(class = "field",
-               if (!is.null(label)) tags$label(label, `for` = inputId),
-               text_input(inputId, value = value, placeholder = placeholder, type = type)
-    )
+    style = if (!is.null(width))
+      glue::glue("width: {shiny::validateCssUnit(width)};"),
+    if (label_class == "ui label" ||
+        grepl("below", label_class, fixed = TRUE) ||
+        grepl("right", label_class, fixed = TRUE)) {
+      shiny::div(
+        class = class,
+        shiny::div(class = label_class,
+                   if (!is.null(label))
+                     tags$label(label, `for` = inputId)),
+        text_input(
+          inputId,
+          value = value,
+          placeholder = placeholder,
+          type = type
+        )
+      )
+    } else {
+      shiny::div(
+        class = class,
+        text_input(
+          inputId,
+          value = value,
+          placeholder = placeholder,
+          type = type
+        ),
+        shiny::div(class = label_class,
+                   if (!is.null(label))
+                     tags$label(label, `for` = inputId))
+      )
+    }
   )
 }
 

--- a/examples/form_inputs/app.R
+++ b/examples/form_inputs/app.R
@@ -20,6 +20,44 @@ ui <- shinyUI(
                 text_input("text_ex", value = "", type = "text", placeholder = "Enter Text...")
               ),
               field(
+                textInput("text_ex",
+                           value = "",
+                           type = "text",
+                           placeholder = "Enter Text...",
+                           label = "Text",
+                           class = "ui right labeled input"
+                )
+              ),
+              field(
+                textInput("text_ex",
+                           value = "",
+                           type = "text",
+                           placeholder = "Enter Text...",
+                           label = "Text",
+                           label_class = "ui pointing below blue label",
+                )
+              ),
+              field(
+                textInput("text_ex",
+                           value = "",
+                           type = "text",
+                           placeholder = "Enter Text...",
+                           label = "Text",
+                           class = "inline field",
+                           label_class = "ui left purple basic tag label",
+                )
+              ),
+              field(
+                textInput("text_ex",
+                           value = "",
+                           type = "text",
+                           placeholder = "Enter Text...",
+                           label = "Text",
+                           class = "inline field",
+                           label_class = "ui right pointing label",
+                )
+              ),
+              field(
                 tags$label("Text Area"),
                 text_input(
                   "textarea_ex", value = "", type = "textarea", placeholder = "Enter Text...", attribs = list(rows = 2)

--- a/tests/testthat/test_input.R
+++ b/tests/testthat/test_input.R
@@ -32,7 +32,28 @@ test_that("test textInput", {
   si_str <- as.character(textInput("text_input", "Text Input"))
   expect_true(any(grepl("<div class=\"ui form\">\n  <div class=\"field\">",
                         si_str, fixed = TRUE)))
-
+  #input label
+  si_str <- as.character(
+    textInput(
+      "text_ex",
+      value = "",
+      type = "text",
+      placeholder = "Enter Text...",
+      label = "Text",
+      class = "ui right labeled input",
+      label_class = "ui blue label"
+    )
+  )
+  expect_true(any(
+    grepl(
+      "<div class=\"ui form\">\n  <div class=\"ui right labeled input\">\n",
+      si_str,
+      fixed = TRUE
+    )
+  ) &&
+    any(grepl(
+      "<div class=\"ui blue label\">\n", si_str, fixed = TRUE
+    )))
 })
 
 test_that("test textAreaInput", {


### PR DESCRIPTION
Closes #235 

This PR provides to add fomanticUI label classes to inputs. This way, the input's label position/type/color can be set.
Basic examples for its use are included in the example file.
[Official documentation](https://fomantic-ui.com/elements/label.html) is referenced.

**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
