### PR TITLE
Add placeholder to numeric_input

### DIFF
--- a/R/input.R
+++ b/R/input.R
@@ -185,7 +185,7 @@ numeric_input <- function(input_id, label, value = NULL, min = NA, max = NA, ste
     stop ("'placeholder' should be NULL or character")
   }
   if (is.null(value) & is.null(placeholder)) stop ("either 'value' or 'placeholder' should be defined")
-  if (!is.null(value) & is.null(placeholder)) {
+  if (!is.null(value)) {
     if (!is.numeric(value) & !grepl("^\\d*(\\.\\d*|)$", value)) stop("Non-numeric input detected")
   }
   

--- a/R/input.R
+++ b/R/input.R
@@ -159,7 +159,7 @@ textInput <- function(inputId, label, value = "", width = NULL,
 #' @param type Input type specifying class attached to input container.
 #'   See [Fomantic UI](https://fomantic-ui.com/collections/form.html) for details.
 #' @param icon Icon or label attached to numeric input.
-#' @param placeholder Inner input label displayed when no value is specified.
+#' @param placeholder Inner input label displayed when no value is specified. Should be NULL or a string
 #' @param ... Unused.
 #' @param label character with label
 #'
@@ -216,15 +216,16 @@ numeric_input <- function(input_id, label, value = NULL, min = NA, max = NA, ste
 #' @param max Maximum allowed value.
 #' @param step Interval to use when stepping between min and max.
 #' @param width The width of the input.
+#' @param placeholder Inner input label displayed when no value is specified. Should be NULL or a string
 #' @param ... Other parameters passed to \code{\link{numeric_input}} like \code{type} or \code{icon}.
 #' @rdname numeric_input
 #' @export
-numericInput <- function(inputId, label, value = NULL,
-                         min = NA, max = NA, step = NA, width = NULL, ...) {
+numericInput <- function(inputId, label, value = NULL, min = NA, max = NA,
+                         step = NA, width = NULL, placeholder = NULL, ...) {
   shiny::div(
     class = "ui form",
     style = if (!is.null(width)) glue::glue("width: {shiny::validateCssUnit(width)};"),
-    numeric_input(inputId, label, value, min, max, step, ...)
+    numeric_input(inputId, label, value, min, max, step, placeholder = placeholder, ...)
   )
 }
 

--- a/R/input.R
+++ b/R/input.R
@@ -159,11 +159,12 @@ textInput <- function(inputId, label, value = "", width = NULL,
 #' @param type Input type specifying class attached to input container.
 #'   See [Fomantic UI](https://fomantic-ui.com/collections/form.html) for details.
 #' @param icon Icon or label attached to numeric input.
-#' @param placeholder Inner input label displayed when no value is specified. Should be NULL or a string
+#' @param placeholder Inner input label displayed when no value is specified.
 #' @param ... Unused.
 #' @param label character with label
 #'
 #' @details
+#' Either `value` or `placeholder` should be defined.
 #' The inputs are updateable by using \code{\link{updateNumericInput}}.
 #' @rdname numeric_input
 #' @examples
@@ -216,7 +217,7 @@ numeric_input <- function(input_id, label, value = NULL, min = NA, max = NA, ste
 #' @param max Maximum allowed value.
 #' @param step Interval to use when stepping between min and max.
 #' @param width The width of the input.
-#' @param placeholder Inner input label displayed when no value is specified. Should be NULL or a string
+#' @param placeholder Inner input label displayed when no value is specified
 #' @param ... Other parameters passed to \code{\link{numeric_input}} like \code{type} or \code{icon}.
 #' @rdname numeric_input
 #' @export

--- a/R/input.R
+++ b/R/input.R
@@ -179,11 +179,17 @@ textInput <- function(inputId, label, value = "", width = NULL,
 #' }
 #'
 #' @export
-numeric_input <- function(input_id, label, value, min = NA, max = NA, step = NA,
+numeric_input <- function(input_id, label, value = NULL, min = NA, max = NA, step = NA,
                            type = NULL, icon = NULL, placeholder = NULL, ...) {
-  if (!is.numeric(value) & !grepl("^\\d*(\\.\\d*|)$", value)) stop("Non-numeric input detected")
+  if (!(is.null(placeholder) || is.character(placeholder))) {
+    stop ("placeholder should be NULL or character")
+  }
+  if (!is.null(value) & is.null(placeholder)) {
+    if (!is.numeric(value) & !grepl("^\\d*(\\.\\d*|)$", value)) stop("Non-numeric input detected")
+  }
+  
 
-  input_tag <- tags$input(id = input_id, value = value, type = "number")
+  input_tag <- tags$input(id = input_id, value = value, type = "number", placeholder = placeholder)
   if (!is.na(min)) input_tag$attribs$min <- min
   if (!is.na(max)) input_tag$attribs$max <- max
   if (!is.na(step)) input_tag$attribs$step <- step
@@ -212,7 +218,7 @@ numeric_input <- function(input_id, label, value, min = NA, max = NA, step = NA,
 #' @param ... Other parameters passed to \code{\link{numeric_input}} like \code{type} or \code{icon}.
 #' @rdname numeric_input
 #' @export
-numericInput <- function(inputId, label, value,
+numericInput <- function(inputId, label, value = NULL,
                          min = NA, max = NA, step = NA, width = NULL, ...) {
   shiny::div(
     class = "ui form",

--- a/R/input.R
+++ b/R/input.R
@@ -182,8 +182,9 @@ textInput <- function(inputId, label, value = "", width = NULL,
 numeric_input <- function(input_id, label, value = NULL, min = NA, max = NA, step = NA,
                            type = NULL, icon = NULL, placeholder = NULL, ...) {
   if (!(is.null(placeholder) || is.character(placeholder))) {
-    stop ("placeholder should be NULL or character")
+    stop ("'placeholder' should be NULL or character")
   }
+  if (is.null(value) & is.null(placeholder)) stop ("either 'value' or 'placeholder' should be defined")
   if (!is.null(value) & is.null(placeholder)) {
     if (!is.numeric(value) & !grepl("^\\d*(\\.\\d*|)$", value)) stop("Non-numeric input detected")
   }

--- a/man/numeric_input.Rd
+++ b/man/numeric_input.Rd
@@ -8,7 +8,7 @@
 numeric_input(
   input_id,
   label,
-  value,
+  value = NULL,
   min = NA,
   max = NA,
   step = NA,
@@ -21,11 +21,12 @@ numeric_input(
 numericInput(
   inputId,
   label,
-  value,
+  value = NULL,
   min = NA,
   max = NA,
   step = NA,
   width = NULL,
+  placeholder = NULL,
   ...
 )
 }
@@ -47,7 +48,7 @@ See [Fomantic UI](https://fomantic-ui.com/collections/form.html) for details.}
 
 \item{icon}{Icon or label attached to numeric input.}
 
-\item{placeholder}{Inner input label displayed when no value is specified.}
+\item{placeholder}{Inner input label displayed when no value is specified. Should be NULL or a string}
 
 \item{...}{Other parameters passed to \code{\link{numeric_input}} like \code{type} or \code{icon}.}
 

--- a/man/numeric_input.Rd
+++ b/man/numeric_input.Rd
@@ -48,7 +48,7 @@ See [Fomantic UI](https://fomantic-ui.com/collections/form.html) for details.}
 
 \item{icon}{Icon or label attached to numeric input.}
 
-\item{placeholder}{Inner input label displayed when no value is specified. Should be NULL or a string}
+\item{placeholder}{Inner input label displayed when no value is specified}
 
 \item{...}{Other parameters passed to \code{\link{numeric_input}} like \code{type} or \code{icon}.}
 
@@ -61,6 +61,7 @@ This creates a default numeric input using Semantic UI. The input is available
 under \code{input[[input_id]]}.
 }
 \details{
+Either `value` or `placeholder` should be defined.
 The inputs are updateable by using \code{\link{updateNumericInput}}.
 }
 \examples{

--- a/tests/testthat/test_input.R
+++ b/tests/testthat/test_input.R
@@ -53,12 +53,15 @@ test_that("test numeric_input", {
   expect_error(numeric_input())
   # text input
   expect_error(numeric_input("number input", "label","Text input"))
+  # non-character and non NULL placeholder
+  expect_error(numeric_input("number input", "label", NULL, placeholder = 4))
   # number input
   si_str <- as.character(numeric_input("number_input", "label", 20))
   expect_true(any(grepl("<input id=\"number_input\" value=\"20\" type=\"number\"/>",
                         si_str, fixed = TRUE)))
   # all parameters
-  expect_is(numeric_input("number_input", "label", 20, min = 10, max = 40, step = 1),
+  expect_is(numeric_input("number_input", "label", 20, min = 10, max = 40, step = 1, 
+    placeholder = "please type an input"),
             "shiny.tag")
 })
 
@@ -67,7 +70,7 @@ test_that("test numericInput", {
   expect_is(numericInput("numberinput", "NLabel", 20), "shiny.tag")
   # empty input
   expect_error(numericInput())
-  expect_error(numericInput("a", "label"), "\"value\" is missing")
+  expect_error(numericInput("a", "label"), "either value or placeholder should be defined")
 })
 
 test_that("test file_input", {

--- a/tests/testthat/test_input.R
+++ b/tests/testthat/test_input.R
@@ -70,7 +70,7 @@ test_that("test numericInput", {
   expect_is(numericInput("numberinput", "NLabel", 20), "shiny.tag")
   # empty input
   expect_error(numericInput())
-  expect_error(numericInput("a", "label"), "either value or placeholder should be defined")
+  expect_error(numericInput("a", "label"), "either 'value' or 'placeholder' should be defined")
 })
 
 test_that("test file_input", {


### PR DESCRIPTION
Short description (with a reference to an issue).

This PR closes the following issue: #428 

It includes a change in the tag creation of the `numeric_input`
Additionally, the checks that the placeholder type is character.
It also has the updated unit tests to check as well the placeholder argument.

This app creates a placeholder as `value` in the `numeric_input` is NULL
```
library(shiny)
library(shiny.semantic)
ui <- semanticPage(
  numeric_input("ex", "Select number", value = NULL, placeholder = "type value")
)
server <- function(input, output, session) {}
shinyApp(ui, server)
```
![image](https://user-images.githubusercontent.com/35930244/215484902-80287ca4-0b7d-4c75-b2be-b1d899f3a8dc.png)


**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
