### PR TITLE
Fix: Updates CDN Path to Library 2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## Upcoming
 
+- upgrade to library 2.9.2
+
 ## [0.4.2]
 
 ### Added

--- a/R/semanticPage.R
+++ b/R/semanticPage.R
@@ -9,7 +9,10 @@
 #' @return CDN path of semantic dependencies
 #' @keywords internal
 get_cdn_path <- function() {
-  getOption("shiny.custom.semantic.cdn", default = "https://d335w9rbwpvuxm.cloudfront.net/2.8.3")
+  getOption(
+    "shiny.custom.semantic.cdn",
+    default = "https://cdnjs.cloudflare.com/ajax/libs/fomantic-ui/2.9.2"
+  )
 }
 
 #' Add dashboard dependencies to html


### PR DESCRIPTION
Closes #434 

* `get_cdn_path()` should now default to [library 2.9.2](https://cdnjs.cloudflare.com/ajax/libs/fomantic-ui/2.9.2).

**DoD**

- [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.

- [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.

- [ ] No new error or warning messages are introduced.

- [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.

- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 

- [ ] All code has been peer-reviewed before merging into any main branch.

- [ ] All changes have been merged into the main branch we use for development (develop).

- [ ] Continuous integration checks (linter, unit tests) are configured and passed.

- [ ] Unit tests added for all new or changed logic.

- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.

- [ ] Any added or touched code follows our style-guide.
