### PR TITLE
chore: Add CRAN-required package alias.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ Suggests:
     markdown,
     rcmdcheck,
     mockery
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -20,6 +20,7 @@
 #'
 #' @docType package
 #' @name shiny.semantic
+#' @aliases shiny.semantic-package
 NULL
 
 #' Internal function that expose javascript bindings to Shiny app.

--- a/man/shiny.semantic.Rd
+++ b/man/shiny.semantic.Rd
@@ -3,6 +3,7 @@
 \docType{package}
 \name{shiny.semantic}
 \alias{shiny.semantic}
+\alias{shiny.semantic-package}
 \title{Semantic UI wrapper for Shiny}
 \description{
 With this library it’s easy to wrap Shiny with Semantic UI


### PR DESCRIPTION
Fixes the issue: using @docType package no longer automatically adds a -package alias.