### PR TITLE
Format PR template and limit workflow runs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,23 +3,13 @@ Short description (with a reference to an issue).
 **DoD**
 
 - [ ] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.
-
 - [ ] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.
-
 - [ ] No new error or warning messages are introduced.
-
 - [ ] All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.
-
-- [ ] If the change affects code or repo sctructure, README, documentation and code comments should be updated. 
-
+- [ ] If the change affects code or repo structure, README, documentation and code comments should be updated. 
 - [ ] All code has been peer-reviewed before merging into any main branch.
-
 - [ ] All changes have been merged into the main branch we use for development (develop).
-
 - [ ] Continuous integration checks (linter, unit tests) are configured and passed.
-
 - [ ] Unit tests added for all new or changed logic.
-
 - [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.
-
 - [ ] Any added or touched code follows our style-guide.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,10 @@
-on: push
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+  workflow_dispatch:
 
 name: R-CMD-check
 


### PR DESCRIPTION
This PR:
 - fixes formatting of the PR template
 - reduced eagerness of CI (it won't run on every single push to every single branch anymore)

The latter came when I saw workflow trigger on markdown change 😬