### PR TITLE
458 dropdown clear

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,6 +51,7 @@ Suggests:
     rcmdcheck,
     rmarkdown,
     testthat,
+    shinytest2,
     tibble,
     withr
 VignetteBuilder:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: shiny.semantic
 Title: Semantic UI Support for Shiny
-Version: 0.5.0.9002
+Version: 0.5.0.9003
 Authors@R: c(person("Filip", "Stachura", email = "filip@appsilon.com", role = "aut"),
   person("Dominik", "Krzeminski", role = "aut"),
   person("Krystian", "Igras", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - `semantic_DT` now accepts style and class arguments.
 
+-  **Breaking change:** fixed `update_dropdown_input`. It now clears the dropdown on `value = character(0)` and `value = ""`.
+
 # [shiny.semantic 0.5.0](https://github.com/Appsilon/shiny.semantic/releases/tag/0.5.0)
 
 - `shiny.semantic` no longer uses CDN as the default source of assets. Instead, `semantic.assets` package was introduced.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,9 @@
 
 - `semantic_DT` now accepts style and class arguments.
 
--  **Breaking change:** fixed `update_dropdown_input`. It now clears the dropdown on `value = character(0)` and `value = ""`.
+-  **Breaking change:** fixed `update_dropdown_input`.
+  - It now clears the dropdown on `value = character(0)` and `value = ""`.
+  - It now clears the dropdown on `choices` update.
 
 # [shiny.semantic 0.5.0](https://github.com/Appsilon/shiny.semantic/releases/tag/0.5.0)
 

--- a/R/dropdown.R
+++ b/R/dropdown.R
@@ -149,8 +149,17 @@ selectInput <- function(inputId, label, choices, selected = NULL, multiple = FAL
 #' @param input_id The id of the input object
 #' @param choices All available options one can select from. If no need to update then leave as \code{NULL}
 #' @param choices_value What reactive value should be used for corresponding choice.
-#' @param value A value to update dropdown to. \code{character(0)} and \code{""} clear the dropdown.
-#' \code{NULL} (the default) does not change selection.
+#' @param value A value to update dropdown to. Defaults to \code{NULL}.
+#' \itemize{
+#'   \item a value from \code{choices} updates the selection
+#'   \item \code{character(0)} and \code{""} clear the selection
+#'   \item \code{NULL}:
+#'   \itemize{
+#'     \item clears the selection if \code{choices} is provided
+#'     \item otherwise, \code{NULL} does not change the selection
+#'   }
+#'   \item a value not found in \code{choices} does not change the selection
+#' }
 #'
 #' @examples
 #' if (interactive()) {

--- a/R/dropdown.R
+++ b/R/dropdown.R
@@ -149,7 +149,8 @@ selectInput <- function(inputId, label, choices, selected = NULL, multiple = FAL
 #' @param input_id The id of the input object
 #' @param choices All available options one can select from. If no need to update then leave as \code{NULL}
 #' @param choices_value What reactive value should be used for corresponding choice.
-#' @param value The initially selected value.
+#' @param value A value to update dropdown to. \code{character(0)} and \code{""} clear the dropdown.
+#' \code{NULL} (the default) does not change selection.
 #'
 #' @examples
 #' if (interactive()) {

--- a/R/dropdown.R
+++ b/R/dropdown.R
@@ -177,17 +177,14 @@ selectInput <- function(inputId, label, choices, selected = NULL, multiple = FAL
 #'
 #' @export
 update_dropdown_input <- function(session, input_id, choices = NULL, choices_value = choices, value = NULL) {
-  if (!is.null(value)) value <- paste(as.character(value), collapse = ",") else value <- NULL
-  if (!is.null(choices)) {
-    options <- jsonlite::toJSON(list(values = data.frame(name = choices, text = choices, value = choices_value)))
-  } else {
-    options <- NULL
+  msg <- list()
+  if (!is.null(value)) {
+    msg$value <- paste(as.character(value), collapse = ",") # NOTE: paste() converts character(0) to ""
   }
-
-  message <- list(choices = options, value = value)
-  message <- message[!vapply(message, is.null, FUN.VALUE = logical(1))]
-
-  session$sendInputMessage(input_id, message)
+  if (!is.null(choices)) {
+    msg$choices <- jsonlite::toJSON(list(values = data.frame(name = choices, text = choices, value = choices_value)))
+  }
+  session$sendInputMessage(input_id, msg)
 }
 
 #' Change the value of a select input on the client

--- a/inst/www/shiny-semantic-dropdown.js
+++ b/inst/www/shiny-semantic-dropdown.js
@@ -32,6 +32,10 @@ $.extend(semanticDropdownBinding, {
 
   // Given the DOM element for the input, set the value.
   setValue: function(el, value) {
+    if (value === '') {
+      $(el).dropdown('clear');
+      return;
+    }
     if ($(el).hasClass('multiple')) {
       $(el).dropdown('clear', true);
       value.split(",").map(v => $(el).dropdown('set selected', v));

--- a/inst/www/shiny-semantic-dropdown.js
+++ b/inst/www/shiny-semantic-dropdown.js
@@ -63,22 +63,15 @@ $.extend(semanticDropdownBinding, {
   },
 
   receiveMessage: function(el, data) {
+    let value = data.value;
     if (data.hasOwnProperty('choices')) {
       // setup menu changes dropdown options without triggering onChange event
       $(el).dropdown('setup menu', data.choices);
-      // when no value passed, return null for multiple dropdown and first value for single one
-      if (!data.hasOwnProperty('value')) {
-        let value = ""
-        if (!$(el).hasClass('multiple')) {
-          value = data.choices.values[0].value
-        }
-        this.setValue(el, value);
-      }
+      // either keep the value provided or use the fact that an empty string clears the input and triggers a change event
+      value ||= ""
     }
 
-    if (data.hasOwnProperty('value')) {
-      this.setValue(el, data.value);
-    }
+    this.setValue(el, value);
 
     if (data.hasOwnProperty('label')) {
       $("label[for='" + el.id + "'").html(data.label);

--- a/man/update_dropdown_input.Rd
+++ b/man/update_dropdown_input.Rd
@@ -21,8 +21,17 @@ update_dropdown_input(
 
 \item{choices_value}{What reactive value should be used for corresponding choice.}
 
-\item{value}{A value to update dropdown to. \code{character(0)} and \code{""} clear the dropdown.
-\code{NULL} (the default) does not change selection.}
+\item{value}{A value to update dropdown to. Defaults to \code{NULL}.
+\itemize{
+  \item a value from \code{choices} updates the selection
+  \item \code{character(0)} and \code{""} clear the selection
+  \item \code{NULL}:
+  \itemize{
+    \item clears the selection if \code{choices} is provided
+    \item otherwise, \code{NULL} does not change the selection
+  }
+  \item a value not found in \code{choices} does not change the selection
+}}
 }
 \description{
 Change the value of a \code{\link{dropdown_input}} input on the client.

--- a/man/update_dropdown_input.Rd
+++ b/man/update_dropdown_input.Rd
@@ -21,7 +21,8 @@ update_dropdown_input(
 
 \item{choices_value}{What reactive value should be used for corresponding choice.}
 
-\item{value}{The initially selected value.}
+\item{value}{A value to update dropdown to. \code{character(0)} and \code{""} clear the dropdown.
+\code{NULL} (the default) does not change selection.}
 }
 \description{
 Change the value of a \code{\link{dropdown_input}} input on the client.

--- a/tests/testthat/test_dropdown.R
+++ b/tests/testthat/test_dropdown.R
@@ -57,6 +57,22 @@ describe("update_dropdown_input", {
     )
   })
 
+  it("is a no-op with a value not in choices", {
+    # Arrange
+    initial_value <- "A"
+    app <- init_driver(test_app(value = "asdf", initial = initial_value, multiple = FALSE))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      initial_value
+    )
+  })
+
   it("updates a single-selection dropdown with a new value", {
     # Arrange
     value <- "A"
@@ -147,26 +163,9 @@ describe("update_dropdown_input", {
     )
   })
 
-  it("updates choices and selects the first element with value = NULL", {
+  it("updates choices and clears selection in a single-selection dropdown when provided with choices and a NULL value", {
     # Arrange
-    choices <- c("abc", "xyz")
-    app <- init_driver(test_app(value = NULL, initial = NULL, multiple = FALSE, choices = choices))
-    withr::defer(app$stop())
-
-    # Act
-    app$click("trigger")
-
-    # Assert
-    expect_equal(
-      app$get_value(input = "dropdown"),
-      choices[1]
-    )
-  })
-
-  it("updates choices and clears selection with value = \"\"", {
-    # Arrange
-    choices <- c("abc", "xyz")
-    app <- init_driver(test_app(value = "", initial = NULL, multiple = FALSE, choices = choices))
+    app <- init_driver(test_app(value = NULL, initial = "abc", multiple = FALSE, choices = c("abc", "xyz")))
     withr::defer(app$stop())
 
     # Act
@@ -176,6 +175,52 @@ describe("update_dropdown_input", {
     expect_equal(
       app$get_value(input = "dropdown"),
       ""
+    )
+  })
+
+  it("updates choices and clears selection in a multi-selection dropdown when provided with choices and a NULL value", {
+    # Arrange
+    app <- init_driver(test_app(value = NULL, initial = "abc", multiple = TRUE, choices = c("abc", "xyz")))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_null(
+      app$get_value(input = "dropdown")
+    )
+  })
+
+  it("updates choices and sets selection in a single-selection dropdown when provided with both choices and a value", {
+    # Arrange
+    value <- "xyz"
+    app <- init_driver(test_app(value = value, initial = NULL, multiple = FALSE, choices = c("abc", "xyz")))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      value
+    )
+  })
+
+  it("updates choices and sets selection in a multi-selection dropdown when provided with both choices and a value", {
+    # Arrange
+    value <- c("abc", "xyz")
+    app <- init_driver(test_app(value = value, initial = NULL, multiple = TRUE, choices = c("abc", "xyz")))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      value
     )
   })
 })

--- a/tests/testthat/test_dropdown.R
+++ b/tests/testthat/test_dropdown.R
@@ -17,3 +17,165 @@ test_that("test dropdown_input", {
   expect_false(any(grepl("<div class=\"item\" data-value=\"0\">0</div>",
                         si_str, fixed = TRUE)))
 })
+
+init_driver <- function(app) {
+  shinytest2::AppDriver$new(app)
+}
+
+test_app <- function(value, initial, multiple, choices = NULL) {
+  type <- if (multiple) "multiple" else ""
+  shiny::shinyApp(
+    ui = semanticPage(
+      dropdown_input("dropdown", LETTERS, value = initial, type = type),
+      shiny::actionButton("trigger", "Trigger")
+    ),
+    server = function(input, output, session) {
+      shiny::observeEvent(input$trigger, {
+        update_dropdown_input(session, "dropdown", value = value, choices = choices)
+      })
+    }
+  )
+}
+
+describe("update_dropdown_input", {
+  skip_on_cran()
+  local_edition(3)
+
+  it("is a no-op with NULL value", {
+    # Arrange
+    initial_value <- "A"
+    app <- init_driver(test_app(value = NULL, initial = initial_value, multiple = FALSE))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      initial_value
+    )
+  })
+
+  it("updates a single-selection dropdown with a new value", {
+    # Arrange
+    value <- "A"
+    app <- init_driver(test_app(value = value, initial = NULL, multiple = FALSE))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      value
+    )
+  })
+
+  it("updates a multi-selection dropdown with new values", {
+    # Arrange
+    value <- c("A", "B")
+    app <- init_driver(test_app(value = value, initial = NULL, multiple = TRUE))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      value
+    )
+  })
+
+  it("clears a single-selection dropdown with \"\" (empty string)", {
+    # Arrange
+    app <- init_driver(test_app(value = "", initial = "A", multiple = FALSE))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      ""
+    )
+  })
+
+  it("clears a multi-selection dropdown with \"\" (empty string)", {
+    # Arrange
+    app <- init_driver(test_app(value = "", initial = "A", multiple = TRUE))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_null(
+      app$get_value(input = "dropdown")
+    )
+  })
+
+  it("clears a single-selection dropdown with character(0)", {
+    # Arrange
+    app <- init_driver(test_app(value = character(0), initial = "A", multiple = FALSE))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      ""
+    )
+  })
+
+  it("clears a multi-selection dropdown with character(0)", {
+    # Arrange
+    app <- init_driver(test_app(value = character(0), initial = "A", multiple = TRUE))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_null(
+      app$get_value(input = "dropdown")
+    )
+  })
+
+  it("updates choices and selects the first element with value = NULL", {
+    # Arrange
+    choices <- c("abc", "xyz")
+    app <- init_driver(test_app(value = NULL, initial = NULL, multiple = FALSE, choices = choices))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      choices[1]
+    )
+  })
+
+  it("updates choices and clears selection with value = \"\"", {
+    # Arrange
+    choices <- c("abc", "xyz")
+    app <- init_driver(test_app(value = "", initial = NULL, multiple = FALSE, choices = choices))
+    withr::defer(app$stop())
+
+    # Act
+    app$click("trigger")
+
+    # Assert
+    expect_equal(
+      app$get_value(input = "dropdown"),
+      ""
+    )
+  })
+})


### PR DESCRIPTION
Prior to this change only multi-selection dropdown could be cleared. This change makes `update_dropdown_input` behavior analogous to `shiny::updateSelectInput`.

Note: this is a breaking change. Prior to this commit updating with `character(0)` or `""` did not have any effect.

Closes #458 

**DoD**

- [x] Major project work has a corresponding task. If there’s no task for what you are doing, create it. Each task needs to be well defined and described.
- [x] Change has been tested (manually or with automated tests), everything runs correctly and works as expected. No existing functionality is broken.
- [x] No new error or warning messages are introduced.
- ~~All interaction with a semantic functions, examples and docs are written from the perspective of the person using or receiving it. They are understandable and helpful to this person.~~
- [x] If the change affects code or repo structure, README, documentation and code comments should be updated. 
- ~~All code has been peer-reviewed before merging into any main branch.~~
- ~~All changes have been merged into the main branch we use for development (develop).~~
- [x] Continuous integration checks (linter, unit tests) are configured and passed.
- [x] Unit tests added for all new or changed logic.
- [ ] All task requirements satisfied. The reviewer is responsible to verify each aspect of the task.
- ~~Any added or touched code follows our style-guide.~~ The entire codebase could be run through a formatter, so I didn't update this single file.